### PR TITLE
feat: implement smart subdirectory detection to improve Steam save path compatibility

### DIFF
--- a/src/main/backup.js
+++ b/src/main/backup.js
@@ -556,6 +556,17 @@ async function fillPathUid(templatedPath, basePath, placeholderMappings) {
 
     // 1. If there's no uid placeholder, just handle wildcards
     if (!basePath.includes('{{p|uid}}')) {
+        // --- SMART DETECTION FOR SUBDIRECTORIES ---
+        const pathParts = path.parse(basePath);
+        if (pathParts.base.includes('*')) {
+            const subdirectoryPath = path.join(pathParts.dir, '*', pathParts.base);
+            const subDirFiles = tryGlobAndReturnPaths(subdirectoryPath);
+            if (subDirFiles && subDirFiles.length > 0) {
+                return subDirFiles;
+            }
+        }
+        // --- END SMART DETECTION ---
+
         const result = tryGlobAndReturnPaths(basePath);
         return result || [];
     }


### PR DESCRIPTION
 English:
  > Problem:
  > Many entries in the database (sourced from PCGamingWiki) specify save paths at the root level (e.g., .../GameName/*.bin). However, on Steam, many games store saves in
  subdirectories named after the SteamID (e.g., .../GameName/7656119.../*.bin). This causes GSM to fail in detecting Steam saves even when the game is correctly identified.
  >
  > Solution:
  > Modified fillPathUid in src/main/backup.js to add a "smart detection" layer. If a path template doesn't explicitly use {{p|uid}} but contains a wildcard, the app will now
  automatically attempt to look into immediate subdirectories first. 
  >
  > Impact:
  > - Priority: Subdirectories (SteamID folders) are prioritized to ensure the most specific saves are found.
  > - Compatibility: If no subdirectories match, it falls back to the original root-level detection, maintaining compatibility with Epic/GOG/non-Steam versions.
  > - Out-of-the-box experience: Users no longer need to manually edit the database or add custom entries for these common Steam path patterns.

  中文说明 (可作为补充):
  > 问题：
  > 数据库中（来自 PCGamingWiki）的许多存档路径仅标注了根目录（如 .../游戏名/*.bin）。但在 Steam 平台上，大量游戏会将存档存放在以 SteamID 命名的子目录下。这导致 GSM
  即使识别到了游戏安装，也无法自动检测到 Steam 版的存档。
  >
  > 解决方案：
  > 在 src/main/backup.js 的 fillPathUid 函数中增加了“智能探测”逻辑。如果路径模板没有明确标注 {{p|uid}} 但包含通配符，程序会优先尝试探测子目录。
  >
  > 影响：
  > - 优先级： 优先匹配子目录，确保精准抓取 SteamID 目录下的存档。
  > - 兼容性： 如果子目录无结果，自动回退到根目录匹配，不影响 Epic/GOG 等非 Steam 版本。
  > - 用户体验： 极大提升了 Steam 存档的开箱即用识别率，无需用户手动修改数据库。